### PR TITLE
Fixed 9 appearing when less than 9 tabs

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -3,7 +3,7 @@ function setFavicons() {
         .then(tabs => {
             tabs.forEach((tab, index) => {
                 let logicalIndex = index + 1;
-                if (index === tabs.length - 1) {
+                if (tabs.length > 8 && index === tabs.length - 1) {
                     logicalIndex = 9;
                 }
                 else if (index >= 8) return;


### PR DESCRIPTION
Changed background worker script so that if less than 9 tabs are open, a "9" will not appear when holding down CTRL.