### PR TITLE
Fixed icons not being unset when doing a shortcut navigating away from tab

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,5 +1,13 @@
-let ctrlTimer = null;
-let origHref = null;
+const origHref = [];
+const isMac = window.navigator.userAgent.includes('Macintosh');
+
+// TODO: Handle context invalidated
+const sendUnsetMsg = () => chrome.runtime.sendMessage('ctrl_released')
+    .catch(_ => { });
+
+// TODO: Handle context invalidated
+const sendSetMsg = () => chrome.runtime.sendMessage('ctrl_held')
+    .catch(_ => { });
 
 function getFavicons() {
     let favicons = document.querySelectorAll("link[rel*='icon']");
@@ -16,47 +24,43 @@ function getFavicons() {
 }
 
 function isCtrlOrCmd(key) {
-    const isMac = window.navigator.userAgent.includes('Macintosh');
     return isMac && key === 'Meta' || !isMac && key === 'Control';
 }
 
 function setFavicon(faviconUrl) {
     const favicons = getFavicons();
-    const shouldSetOrig = !origHref;
-    if (shouldSetOrig) {
-        origHref = [];
-    }
+    if (origHref.length > 0) return;
 
     for (const favicon of favicons) {
-        if (shouldSetOrig) {
-            origHref.push(favicon.href);
-        }
+        origHref.push(favicon.href);
         favicon.setAttribute('href', faviconUrl);
     }
 }
 
 function unsetFavicon() {
     const favicons = getFavicons();
-    if (origHref) {
-        favicons.forEach((favicon, index) => {
-            favicon.setAttribute('href', origHref[index]);
-        });
-    }
+    if (origHref.length === 0) return;
+
+    favicons.forEach((favicon, index) => {
+        favicon.setAttribute('href', origHref[index]);
+    });
+    origHref.length = 0;
 }
+
+
+document.addEventListener('visibilitychange', sendUnsetMsg);
+window.addEventListener('blur', sendUnsetMsg);
 
 document.addEventListener('keydown', evt => {
     if (!isCtrlOrCmd(evt.key)) return;
 
-    // TODO: Handle context invalidated
-    chrome.runtime.sendMessage('ctrl_held').catch(_ => {});
+    sendSetMsg();
 });
 
 document.addEventListener('keyup', evt => {
     if (!isCtrlOrCmd(evt.key)) return;
 
-    // TODO: Handle context invalidated
-    chrome.runtime.sendMessage('ctrl_released').catch(_ => {});
-    clearTimeout(ctrlTimer);
+    sendUnsetMsg();
 });
 
 chrome.runtime.onMessage.addListener(message => {


### PR DESCRIPTION
Added event listeners for document visibilitychange and window blur to account for favicons not reverting after new tabs or new windows (respectively) being created.