### PR TITLE
Incorrect tab numbers when tab groups are collapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ yarn build
 
 ### Firefox Installation
 
+A separate `dist.firefox/` directory is generated for Firefox browsers since
+they do not properly implement the background Service Worker API from manifest
+V3, therefore it has a different manifest that will utilize V2 instead.
+
 Note that due to the unsigned nature of this extension, it needs to be re-added
 every time firefox is restarted (this is a limitation of the browser itself, so
 I can't work around it).

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -14,7 +14,15 @@ const queryTabs = chrome.runtime.getManifest().manifest_version === 3
   };
 
 async function setFavicons() {
-  const tabs = await queryTabs({currentWindow: true});
+  const tabGroups = await chrome.tabGroups.query({});
+  const tabs = (await queryTabs({
+    currentWindow: true,
+  })).filter(tab => {
+    if (tab.groupId === -1) return true;
+
+    const tabGroup = tabGroups.find((group) => group.id === tab.groupId);
+    return !tabGroup || !tabGroup.collapsed;
+  });
 
   tabs.forEach((tab, index) => {
     // Don't set the favicon if there are more than 8 tabs and the current tab

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -13,12 +13,18 @@ const queryTabs = chrome.runtime.getManifest().manifest_version === 3
     });
   };
 
+// Polyfill to handle tab groups in Firefox (not supported in manifest v2, so
+// just returns an empty array)
+const getTabGroups = chrome.runtime.getManifest().manifest_version === 3
+  ? async () => await chrome.tabGroups.query({})
+  : async () => [];
+
 async function setFavicons() {
-  const tabGroups = await chrome.tabGroups.query({});
+  const tabGroups = await getTabGroups();
   const tabs = (await queryTabs({
     currentWindow: true,
   })).filter(tab => {
-    if (tab.groupId === -1) return true;
+    if (!tab.groupId || tab.groupId === -1) return true;
 
     const tabGroup = tabGroups.find((group) => group.id === tab.groupId);
     return !tabGroup || !tabGroup.collapsed;

--- a/src/scripts/content.ts
+++ b/src/scripts/content.ts
@@ -2,13 +2,11 @@ const origHref: string[] = [];
 const isMac: boolean = window.navigator.userAgent.includes('Macintosh');
 
 async function sendSetMsg(): Promise<void> {
-  // Don't do anything if extension context is invalidated
   if (!chrome.runtime?.id) return;
   await chrome.runtime.sendMessage('ctrl_held');
 }
 
 async function sendUnsetMsg(): Promise<void> {
-  // Don't do anything if extension context is invalidated
   if (!chrome.runtime?.id) return;
   await chrome.runtime.sendMessage('ctrl_released');
 }

--- a/src/static/manifest.chrome.json
+++ b/src/static/manifest.chrome.json
@@ -5,6 +5,7 @@
   "version": "0.2.0",
   "permissions": [
     "tabs",
+    "tabGroups",
     "scripting"
   ],
   "background": {

--- a/src/static/onboarding/install.html
+++ b/src/static/onboarding/install.html
@@ -19,10 +19,9 @@
         </i>
       </p>
       <p>
-        Thank you for installing my Chromium extension! I hope that you find it
-        as useful as I do, and if not, feel free to complain about it (or fork
-        it) from its
-        <a href="https://github.com/lxsavage/chromium-tab-numbers"
+        Thank you for installing my extension! I hope that you find it as useful
+        as I do, and if not, feel free to complain about it (or fork it) from
+        its <a href="https://github.com/lxsavage/chromium-tab-numbers"
           target="_blank">GitHub Repository</a>.
       </p>
       <p>


### PR DESCRIPTION
- Collapsed tab group tabs are no longer counted with the favicon numbers on Chrome. Needs a polyfill fix for Firefox.
- Added polyfill workaround for tab groups when working with Firefox
